### PR TITLE
Adds file-based resource lock abstraction

### DIFF
--- a/OrangePi.Common/Extensions/DependecyInjection.cs
+++ b/OrangePi.Common/Extensions/DependecyInjection.cs
@@ -87,5 +87,11 @@ namespace OrangePi.Common.Extensions
 
             return services;
         }
+
+        public static IServiceCollection AddI2CDisplayLock(this IServiceCollection services)
+        {
+            services.AddTransient<IResourceLock, I2CDisplayLock>();
+            return services;
+        }
     }
 }

--- a/OrangePi.Common/Services/I2CDisplayLock.cs
+++ b/OrangePi.Common/Services/I2CDisplayLock.cs
@@ -1,0 +1,7 @@
+﻿namespace OrangePi.Common.Services
+{
+    public class I2CDisplayLock: ResourceLock
+    {
+        protected override string LockFilePath => "/var/lock/i2c-display.lock";
+    }
+}

--- a/OrangePi.Common/Services/IGlancesClient.cs
+++ b/OrangePi.Common/Services/IGlancesClient.cs
@@ -1,10 +1,4 @@
 ﻿using OrangePi.Common.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Metadata;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OrangePi.Common.Services
 {

--- a/OrangePi.Common/Services/IPiHoleService.cs
+++ b/OrangePi.Common/Services/IPiHoleService.cs
@@ -1,9 +1,4 @@
 ﻿using OrangePi.Common.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OrangePi.Common.Services
 {

--- a/OrangePi.Common/Services/IResourceLock.cs
+++ b/OrangePi.Common/Services/IResourceLock.cs
@@ -1,0 +1,11 @@
+﻿namespace OrangePi.Common.Services
+{
+    public interface IResourceLock: IDisposable
+    {
+        void Acquire();
+        bool TryAcquire();
+        bool TryAcquire(TimeSpan timeout);
+        void Release();
+        bool IsInUse();
+    }
+}

--- a/OrangePi.Common/Services/ResourceLock.cs
+++ b/OrangePi.Common/Services/ResourceLock.cs
@@ -1,0 +1,85 @@
+﻿namespace OrangePi.Common.Services
+{
+    public abstract class ResourceLock : IResourceLock
+    {
+        protected abstract string LockFilePath { get; }
+
+        private FileStream? _lockFile;
+        private bool _isLocked = false;
+
+        public bool IsInUse()
+        {
+            try
+            {
+                using var probe = new FileStream(
+                    LockFilePath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite,
+                    FileShare.None
+                );
+                return false;
+            }
+            catch (IOException)
+            {
+                return true;
+            }
+        }
+
+        public void Acquire()
+        {
+            _lockFile = new FileStream(
+                LockFilePath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None
+            );
+            _isLocked = true;
+        }
+
+        public bool TryAcquire()
+        {
+            try
+            {
+                _lockFile = new FileStream(
+                    LockFilePath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite,
+                    FileShare.None
+                );
+                _isLocked = true;
+                return true;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+        }
+
+        public bool TryAcquire(TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                if (TryAcquire())
+                    return true;
+
+                Thread.Sleep(50);
+            }
+
+            return false;
+        }
+
+        public void Release()
+        {
+            if (_isLocked && _lockFile != null)
+            {
+                _lockFile.Dispose();
+                _lockFile = null;
+                _isLocked = false;
+            }
+        }
+
+        public void Dispose() => Release();
+    }
+}


### PR DESCRIPTION
Introduces a robust file-based resource locking mechanism to prevent contention when accessing shared hardware resources.

*   **New Abstraction:** Defines an `IResourceLock` interface for standard lock management operations and an abstract `ResourceLock` base class that provides a concrete file-based implementation.
*   **I2C Display Lock:** Implements a specific `I2CDisplayLock` which utilizes a dedicated file at `/var/lock/i2c-display.lock` to ensure exclusive access for I2C display operations.
*   **Dependency Injection:** Provides an extension method `AddI2CDisplayLock` for easy registration and consumption of the I2C display lock within the application's dependency injection container.
*   **Code Clean-up:** Removes redundant `using` directives from several service interface files, improving code clarity.