### PR TITLE
Adds I2C proximity sensor support

### DIFF
--- a/OrangePi.Display.Status.Service/Models/Config/ProximitySensorSwitchConfig.cs
+++ b/OrangePi.Display.Status.Service/Models/Config/ProximitySensorSwitchConfig.cs
@@ -2,7 +2,7 @@
 {
     public class ProximitySensorSwitchConfig
     {
-        public int GPIO { get; set; }
+        public int BusId { get; set; }
         public int Distance { get; set; }
     }
 }

--- a/OrangePi.Display.Status.Service/Program.cs
+++ b/OrangePi.Display.Status.Service/Program.cs
@@ -1,4 +1,3 @@
-// https://learn.microsoft.com/en-us/dotnet/iot/tutorials/lcd-display
 using OrangePi.Common.Extensions;
 using OrangePi.Display.Status.Service;
 using OrangePi.Display.Status.Service.Extensions;
@@ -22,7 +21,6 @@ internal class Program
                 services.AddOptions();
                 services.AddLogging();
                 services.Configure<ServiceConfiguration>(hostContext.Configuration.GetSection(nameof(ServiceConfiguration)));
-                //services.Configure<SwitchConfig>(hostContext.Configuration.GetSection(nameof(SwitchConfig)));
                 services.Configure<SoundConfiguration>(hostContext.Configuration.GetSection(nameof(SoundConfiguration)));
                 services.AddHostedService<Worker>();
 

--- a/OrangePi.Display.Status.Service/Services/Switch/InfraredMotionSensorSwitch.cs
+++ b/OrangePi.Display.Status.Service/Services/Switch/InfraredMotionSensorSwitch.cs
@@ -55,7 +55,7 @@ namespace OrangePi.Display.Status.Service.Services.Switch
                          {
                              this.IsOn = false;
                          }
-                         await Task.Delay(TimeSpan.FromMilliseconds(100)).WaitAsync(stoppingToken);
+                         await Task.Delay(TimeSpan.FromMilliseconds(500)).WaitAsync(stoppingToken);
                      }
                  }
              });

--- a/OrangePi.Display.Status.Service/Services/Switch/ProximitySensorSwitch.cs
+++ b/OrangePi.Display.Status.Service/Services/Switch/ProximitySensorSwitch.cs
@@ -52,20 +52,11 @@ namespace OrangePi.Display.Status.Service.Services.Switch
                 {
                     using (var _distanceSensor = new Vl53L1X(_i2cDevice))
                     {
-                        _distanceSensor.StartRanging();
                         while (!stoppingToken.IsCancellationRequested)
                         {
-                            if (_distanceSensor.GetDistance() <= _triggerDistance)
-                            {
-                                IsOn = true;
-                            }
-                            else
-                            {
-                                IsOn = false;
-                            }
-                            await Task.Delay(TimeSpan.FromMilliseconds(100)).WaitAsync(stoppingToken);
+                            IsOn = _distanceSensor.GetDistance() <= _triggerDistance;
+                            await Task.Delay(TimeSpan.FromMilliseconds(500)).WaitAsync(stoppingToken);
                         }
-                        _distanceSensor.StopRanging();
                     }
                 }
             });

--- a/OrangePi.Display.Status.Service/Services/Switch/ProximitySensorSwitch.cs
+++ b/OrangePi.Display.Status.Service/Services/Switch/ProximitySensorSwitch.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Iot.Device.Vl53L1X;
+using Microsoft.Extensions.Options;
 using OrangePi.Display.Status.Service.Models.Config;
+using System.Device.I2c;
+using UnitsNet;
 
 namespace OrangePi.Display.Status.Service.Services.Switch
 {
@@ -9,10 +12,12 @@ namespace OrangePi.Display.Status.Service.Services.Switch
         public event EventHandler<bool>? Changed;
         readonly object _lock = new Object();
         readonly ProximitySensorSwitchConfig _config;
-
+        private readonly Length _triggerDistance;
         public ProximitySensorSwitch(IOptions<ProximitySensorSwitchConfig> options)
         {
             _config = options.Value;
+            _triggerDistance = Length.FromMillimeters(_config.Distance);
+
         }
 
         public bool IsOn
@@ -37,9 +42,33 @@ namespace OrangePi.Display.Status.Service.Services.Switch
             }
         }
 
-        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        public Task StartMonitoringAsync(CancellationToken stoppingToken)
         {
-            throw new NotImplementedException();
+            return Task.Run(async () =>
+            {
+                var _i2cSettings = new I2cConnectionSettings(1, Vl53L1X.DefaultI2cAddress);
+
+                using (var _i2cDevice = I2cDevice.Create(_i2cSettings))
+                {
+                    using (var _distanceSensor = new Vl53L1X(_i2cDevice))
+                    {
+                        _distanceSensor.StartRanging();
+                        while (!stoppingToken.IsCancellationRequested)
+                        {
+                            if (_distanceSensor.GetDistance() <= _triggerDistance)
+                            {
+                                IsOn = true;
+                            }
+                            else
+                            {
+                                IsOn = false;
+                            }
+                            await Task.Delay(TimeSpan.FromMilliseconds(100)).WaitAsync(stoppingToken);
+                        }
+                        _distanceSensor.StopRanging();
+                    }
+                }
+            });
         }
     }
 }

--- a/OrangePi.Display.Status.Service/Services/Switch/ProximitySensorSwitch.cs
+++ b/OrangePi.Display.Status.Service/Services/Switch/ProximitySensorSwitch.cs
@@ -46,7 +46,7 @@ namespace OrangePi.Display.Status.Service.Services.Switch
         {
             return Task.Run(async () =>
             {
-                var _i2cSettings = new I2cConnectionSettings(1, Vl53L1X.DefaultI2cAddress);
+                var _i2cSettings = new I2cConnectionSettings(_config.BusId, Vl53L1X.DefaultI2cAddress);
 
                 using (var _i2cDevice = I2cDevice.Create(_i2cSettings))
                 {

--- a/OrangePi.Display.Status.Service/Worker.cs
+++ b/OrangePi.Display.Status.Service/Worker.cs
@@ -4,10 +4,8 @@ using OrangePi.Common.Services;
 using OrangePi.Display.Status.Service.Models;
 using OrangePi.Display.Status.Service.Services.Info;
 using OrangePi.Display.Status.Service.Services.Switch;
-using System.Device.Gpio;
 using System.Device.I2c;
 using System.Reflection;
-using UnitsNet;
 
 namespace OrangePi.Display.Status.Service
 {
@@ -23,7 +21,6 @@ namespace OrangePi.Display.Status.Service
         private readonly ServiceConfiguration _serviceConfiguration;
         private readonly SoundConfiguration _soundConfiguration;
         private readonly IProcessRunner _processRunner;
-        readonly System.Timers.Timer _timer;
         readonly IEnumerable<IDisplayInfoService> _displayInfoServices;
         readonly string _currentFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         readonly ISwitch _switch;
@@ -41,10 +38,7 @@ namespace OrangePi.Display.Status.Service
             _serviceConfiguration = serviceConfiguration.Value;
             _soundConfiguration = soundConfig.Value;
             _processRunner = processRunner;
-            //_timer = new System.Timers.Timer(_serviceConfiguration.TimeOnTimeSpan);
-            //_timer.Elapsed += timer_Elapsed;
             SkiaSharpAdapter.Register();
-            _timer.Start();
             _switch = @switch;
             _switch.Changed += _switch_Changed;
         }
@@ -54,11 +48,6 @@ namespace OrangePi.Display.Status.Service
             if (!e && !string.IsNullOrWhiteSpace(_soundConfiguration.ActivationSound) && File.Exists(_soundConfiguration.ActivationSound))
                 _processRunner.Run(command: "play", _soundConfiguration.ActivationSound);
         }
-
-        //private void timer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
-        //{
-        //    Switch = false;
-        //}
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {

--- a/OrangePi.Display.Status.Service/appsettings.json
+++ b/OrangePi.Display.Status.Service/appsettings.json
@@ -25,7 +25,8 @@
       "GPIO": 92
     },
     "ProximitySensorSwitchConfig": {
-      "GPIO": 92
+      "BusId": 5,
+      "Distance": 100
     }
   }
 


### PR DESCRIPTION
*   Implements an I2C-based proximity sensor switch utilizing the VL53L1X sensor to detect object presence based on a configured distance threshold.
*   Updates the `ProximitySensorSwitchConfig` to specify the I2C `BusId` and `Distance` for the trigger, replacing the previous GPIO configuration.
*   Removes an unused timer from the service's main worker, simplifying the overall application logic.
*   Standardizes the check interval for both infrared motion and proximity sensors to 500 milliseconds for consistent monitoring.