### PR TITLE
Refactors display into abstracted Screen service

### DIFF
--- a/OrangePi.Display.Status.Service/Extensions/DependecyInjectionExtensions.cs
+++ b/OrangePi.Display.Status.Service/Extensions/DependecyInjectionExtensions.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using OrangePi.Common.Extensions;
 using OrangePi.Common.Services;
+using OrangePi.Display.Status.Service.Models;
 using OrangePi.Display.Status.Service.Models.Config;
+using OrangePi.Display.Status.Service.Services;
 using OrangePi.Display.Status.Service.Services.Info;
 using OrangePi.Display.Status.Service.Services.Switch;
 
@@ -9,6 +12,19 @@ namespace OrangePi.Display.Status.Service.Extensions
 {
     public static class DependecyInjectionExtensions
     {
+        public static IServiceCollection AddScreen(this IServiceCollection services)
+        {
+            services.AddSingleton<IScreen>(sp =>
+            {
+                var config = sp.GetRequiredService<IOptions<ScreenConfiguration>>().Value;
+                var screen = new Screen(config.BusId, config.DeviceAddress);
+                if (config.Rotate)
+                    screen.Flip([IScreen.FlipType.Horizontally, IScreen.FlipType.Vertically]);
+                return screen;
+            });
+            return services;
+        }
+
         public static IServiceCollection AddCpuInfo(this IServiceCollection services)
         {
             services.TryAddSingleton<IProcessRunner, ProcessRunner>();

--- a/OrangePi.Display.Status.Service/Extensions/InfoServiceExtensions.cs
+++ b/OrangePi.Display.Status.Service/Extensions/InfoServiceExtensions.cs
@@ -1,9 +1,8 @@
 ﻿using Iot.Device.Graphics;
 using Iot.Device.Graphics.SkiaSharpAdapter;
-using OrangePi.Display.Status.Service.Models;
+using OrangePi.Display.Status.Service.Services;
 using OrangePi.Display.Status.Service.Services.Info;
 using SkiaSharp;
-using System.Device.I2c;
 using System.Drawing;
 
 
@@ -202,6 +201,14 @@ namespace OrangePi.Display.Status.Service.Extensions
 
             return image;
 
+        }
+
+        public static async Task DrawInfo(this IScreen screen, IDisplayInfoService displayInfo, int fontSize = 12, string fontName = "DejaVu Sans Bold")
+        {
+            using (var image = await displayInfo.GetInfoDisplay(screen.Width, screen.Height, fontName, fontSize))
+            {
+                screen.DrawImage(image);
+            }
         }
     }
 }

--- a/OrangePi.Display.Status.Service/Models/ScreenConfiguration.cs
+++ b/OrangePi.Display.Status.Service/Models/ScreenConfiguration.cs
@@ -2,9 +2,9 @@
 
 namespace OrangePi.Display.Status.Service.Models
 {
-    public class DisplayConfiguration
+    public class ScreenConfiguration
     {
-        public DisplayConfiguration()
+        public ScreenConfiguration()
         {
             
         }

--- a/OrangePi.Display.Status.Service/Program.cs
+++ b/OrangePi.Display.Status.Service/Program.cs
@@ -1,3 +1,4 @@
+using Iot.Device.Graphics.SkiaSharpAdapter;
 using OrangePi.Common.Extensions;
 using OrangePi.Display.Status.Service;
 using OrangePi.Display.Status.Service.Extensions;
@@ -7,6 +8,8 @@ internal class Program
 {
     private static void Main(string[] args)
     {
+        SkiaSharpAdapter.Register();
+
         IHost host = Host.CreateDefaultBuilder(args)
             .ConfigureAppConfiguration((hostContext, config) =>
             {

--- a/OrangePi.Display.Status.Service/Program.cs
+++ b/OrangePi.Display.Status.Service/Program.cs
@@ -20,7 +20,7 @@ internal class Program
             {
                 services.AddOptions();
                 services.AddLogging();
-                services.Configure<DisplayConfiguration>(hostContext.Configuration.GetSection(nameof(DisplayConfiguration)));
+                services.Configure<ScreenConfiguration>(hostContext.Configuration.GetSection(nameof(ScreenConfiguration)));
                 services.Configure<SoundConfiguration>(hostContext.Configuration.GetSection(nameof(SoundConfiguration)));
                 services.AddHostedService<Worker>();
 

--- a/OrangePi.Display.Status.Service/Program.cs
+++ b/OrangePi.Display.Status.Service/Program.cs
@@ -22,6 +22,7 @@ internal class Program
                 services.AddLogging();
                 services.Configure<ScreenConfiguration>(hostContext.Configuration.GetSection(nameof(ScreenConfiguration)));
                 services.Configure<SoundConfiguration>(hostContext.Configuration.GetSection(nameof(SoundConfiguration)));
+                services.AddScreen();
                 services.AddHostedService<Worker>();
 
                 services.AddProcessRunner();

--- a/OrangePi.Display.Status.Service/Services/IScreen.cs
+++ b/OrangePi.Display.Status.Service/Services/IScreen.cs
@@ -1,0 +1,23 @@
+﻿using Iot.Device.Graphics;
+
+namespace OrangePi.Display.Status.Service.Services
+{
+    public interface IScreen : IDisposable
+    {
+        enum FlipType
+        {
+            Horizontally = 0,
+            Vertically = 1,
+        }
+        public int Width { get; }
+        public int Height { get; }
+
+        void Flip(IEnumerable<FlipType> rotationTypes);
+        void FlipVertically();
+        void FlipHorizontally();
+        void Enable();
+        void Disable();
+        void Clear();
+        void DrawImage(BitmapImage bitmapImage);
+    }
+}

--- a/OrangePi.Display.Status.Service/Services/Screen.cs
+++ b/OrangePi.Display.Status.Service/Services/Screen.cs
@@ -1,0 +1,67 @@
+﻿using Iot.Device.Graphics;
+using Iot.Device.Ssd13xx;
+using OrangePi.Display.Status.Service.Models;
+using System.Device.I2c;
+
+namespace OrangePi.Display.Status.Service.Services
+{
+    public class Screen : IScreen
+    {
+        public int Width => 128;
+
+        public int Height => 64;
+
+        readonly I2cDevice _i2CDevice;
+        readonly Ssd1306 _ssd1306;
+        public Screen(int busId, int deviceAddress)
+        {
+            _i2CDevice = I2cDevice.Create(new I2cConnectionSettings(busId, deviceAddress));
+            _ssd1306 = new Ssd1306(_i2CDevice, Width, Height);
+        }
+
+        public void Clear()
+        {
+            _ssd1306.ClearScreen();
+        }
+
+        public void Disable()
+        {
+            _ssd1306.EnableDisplay(false);
+        }
+
+        public void DrawImage(BitmapImage bitmapImage)
+        {
+            _ssd1306.DrawBitmap(bitmapImage);
+        }
+
+        public void Enable()
+        {
+            _ssd1306.EnableDisplay(true);
+        }
+
+        public void Flip(IEnumerable<IScreen.FlipType> rotationTypes)
+        {
+            if (rotationTypes.Contains(IScreen.FlipType.Horizontally))
+                FlipHorizontally();
+            if (rotationTypes.Contains(IScreen.FlipType.Vertically))
+                FlipVertically();
+        }
+
+        public void FlipHorizontally()
+        {
+            _ssd1306.SendCommand(new Ssd1306Command(0xc0));
+        }
+
+        public void FlipVertically()
+        {
+            _ssd1306.SendCommand(new Ssd1306Command(0xc0));
+        }
+        public void Dispose()
+        {
+            _ssd1306.Dispose();
+            _i2CDevice.Dispose();
+        }
+
+
+    }
+}

--- a/OrangePi.Display.Status.Service/Services/Screen.cs
+++ b/OrangePi.Display.Status.Service/Services/Screen.cs
@@ -1,4 +1,5 @@
 ﻿using Iot.Device.Graphics;
+using Iot.Device.Ssd1351;
 using Iot.Device.Ssd13xx;
 using OrangePi.Display.Status.Service.Models;
 using System.Device.I2c;
@@ -43,13 +44,14 @@ namespace OrangePi.Display.Status.Service.Services
         {
             if (rotationTypes.Contains(IScreen.FlipType.Horizontally))
                 FlipHorizontally();
+
             if (rotationTypes.Contains(IScreen.FlipType.Vertically))
                 FlipVertically();
         }
 
         public void FlipHorizontally()
         {
-            _ssd1306.SendCommand(new Ssd1306Command(0xc0));
+            _ssd1306.SendCommand(new Ssd1306Command(0xa0));
         }
 
         public void FlipVertically()

--- a/OrangePi.Display.Status.Service/Worker.cs
+++ b/OrangePi.Display.Status.Service/Worker.cs
@@ -18,7 +18,7 @@ namespace OrangePi.Display.Status.Service
         readonly int fontSize = 12;
 
         private readonly ILogger<Worker> _logger;
-        private readonly DisplayConfiguration _serviceConfiguration;
+        private readonly ScreenConfiguration _screeConfiguration;
         private readonly SoundConfiguration _soundConfiguration;
         private readonly IProcessRunner _processRunner;
         readonly IEnumerable<IDisplayInfoService> _displayInfoServices;
@@ -45,7 +45,7 @@ namespace OrangePi.Display.Status.Service
         }
         public Worker(
             ILogger<Worker> logger,
-            IOptions<DisplayConfiguration> serviceConfiguration,
+            IOptions<ScreenConfiguration> serviceConfiguration,
             IOptions<SoundConfiguration> soundConfig,
             IEnumerable<IInfoService> infoServices,
             IProcessRunner processRunner,
@@ -54,7 +54,7 @@ namespace OrangePi.Display.Status.Service
         {
             _logger = logger;
             _displayInfoServices = infoServices.Select(s => s as IDisplayInfoService).ToList();
-            _serviceConfiguration = serviceConfiguration.Value;
+            _screeConfiguration = serviceConfiguration.Value;
             _soundConfiguration = soundConfig.Value;
             _processRunner = processRunner;
             SkiaSharpAdapter.Register();
@@ -62,7 +62,7 @@ namespace OrangePi.Display.Status.Service
             _switch.Changed += _switch_Changed;
 
             IsPlaying = true;
-            _playTimer = new System.Timers.Timer(_serviceConfiguration.TimeOnTimeSpan)
+            _playTimer = new System.Timers.Timer(_screeConfiguration.TimeOnTimeSpan)
             {
                 Enabled = true,
                 AutoReset = false
@@ -96,14 +96,14 @@ namespace OrangePi.Display.Status.Service
                 _processRunner.Run(command: "play", _soundConfiguration.ActivationSound);
 
             var switchMonitor = _switch.StartMonitoringAsync(stoppingToken);
-            var pause = _serviceConfiguration.IntervalTimeSpan;
+            var pause = _screeConfiguration.IntervalTimeSpan;
 
             //https://pinout.xyz/pinout/i2c
-            using (var device = I2cDevice.Create(new I2cConnectionSettings(_serviceConfiguration.BusId, _serviceConfiguration.DeviceAddress)))
+            using (var device = I2cDevice.Create(new I2cConnectionSettings(_screeConfiguration.BusId, _screeConfiguration.DeviceAddress)))
             {
                 using (var ssd1306 = new Iot.Device.Ssd13xx.Ssd1306(device, screenWidth, screenHeight))
                 {
-                    if (_serviceConfiguration.Rotate)
+                    if (_screeConfiguration.Rotate)
                     {
                         ssd1306.SendCommand(new Ssd1306Command(0xc0));//Flip vertically
                         ssd1306.SendCommand(new Ssd1306Command(0xa0));//Flip horizontally

--- a/OrangePi.Display.Status.Service/Worker.cs
+++ b/OrangePi.Display.Status.Service/Worker.cs
@@ -2,9 +2,9 @@ using Iot.Device.Graphics.SkiaSharpAdapter;
 using Microsoft.Extensions.Options;
 using OrangePi.Common.Services;
 using OrangePi.Display.Status.Service.Models;
+using OrangePi.Display.Status.Service.Services;
 using OrangePi.Display.Status.Service.Services.Info;
 using OrangePi.Display.Status.Service.Services.Switch;
-using System.Device.I2c;
 using System.Reflection;
 
 namespace OrangePi.Display.Status.Service
@@ -12,8 +12,6 @@ namespace OrangePi.Display.Status.Service
     public class Worker : BackgroundService
     {
 
-        readonly int screenWidth = 128;
-        readonly int screenHeight = 64;
         readonly string fontName = "DejaVu Sans Bold";
         readonly int fontSize = 12;
 
@@ -24,6 +22,7 @@ namespace OrangePi.Display.Status.Service
         readonly IEnumerable<IDisplayInfoService> _displayInfoServices;
         readonly string _currentFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         readonly ISwitch _switch;
+        readonly IScreen _screen;
         readonly System.Timers.Timer _playTimer;
 
 
@@ -49,7 +48,8 @@ namespace OrangePi.Display.Status.Service
             IOptions<SoundConfiguration> soundConfig,
             IEnumerable<IInfoService> infoServices,
             IProcessRunner processRunner,
-            ISwitch @switch
+            ISwitch @switch,
+            IScreen screen
             )
         {
             _logger = logger;
@@ -59,6 +59,7 @@ namespace OrangePi.Display.Status.Service
             _processRunner = processRunner;
             SkiaSharpAdapter.Register();
             _switch = @switch;
+            _screen = screen;
             _switch.Changed += _switch_Changed;
 
             IsPlaying = true;
@@ -98,45 +99,31 @@ namespace OrangePi.Display.Status.Service
             var switchMonitor = _switch.StartMonitoringAsync(stoppingToken);
             var pause = _screeConfiguration.IntervalTimeSpan;
 
-            //https://pinout.xyz/pinout/i2c
-            using (var device = I2cDevice.Create(new I2cConnectionSettings(_screeConfiguration.BusId, _screeConfiguration.DeviceAddress)))
+            while (!stoppingToken.IsCancellationRequested)
             {
-                using (var ssd1306 = new Iot.Device.Ssd13xx.Ssd1306(device, screenWidth, screenHeight))
+                if (!IsPlaying)
                 {
-                    if (_screeConfiguration.Rotate)
+                    _screen.Disable();
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), stoppingToken);
+                    continue;
+                }
+
+                _screen.Enable();
+
+                foreach (var infoService in _displayInfoServices)
+                {
+                    if (stoppingToken.IsCancellationRequested)
+                        break;
+
+                    using (var image = await infoService.GetInfoDisplay(_screen.Width, _screen.Height, fontName, fontSize))
                     {
-                        ssd1306.SendCommand(new Ssd1306Command(0xc0));//Flip vertically
-                        ssd1306.SendCommand(new Ssd1306Command(0xa0));//Flip horizontally
+                        _screen.DrawImage(image);
                     }
-
-                    while (!stoppingToken.IsCancellationRequested)
-                    {
-                        if (!IsPlaying)
-                        {
-                            ssd1306.EnableDisplay(false);
-                            await Task.Delay(TimeSpan.FromMilliseconds(100));
-                            continue;
-                        }
-
-                        ssd1306.EnableDisplay(true);
-
-                        foreach (var infoService in _displayInfoServices)
-                        {
-                            if (stoppingToken.IsCancellationRequested)
-                                break;
-
-                            using (var image = await infoService.GetInfoDisplay(screenWidth, screenHeight, fontName, fontSize))
-                            {
-                                ssd1306.DrawBitmap(image);
-                            }
-                            await Task.Delay(pause);
-                        }
-
-                    }
-
-                    ssd1306.ClearScreen();
+                    await Task.Delay(pause);
                 }
             }
+
+            _screen.Clear();
 
             await switchMonitor.WaitAsync(stoppingToken);
         }

--- a/OrangePi.Display.Status.Service/appsettings.json
+++ b/OrangePi.Display.Status.Service/appsettings.json
@@ -5,7 +5,7 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "DisplayConfiguration": {
+  "ScreenConfiguration": {
     "BusId": 5,
     "DeviceAddressHex": "0x3c",
     "Interval": 3,


### PR DESCRIPTION
Introduces a dedicated `IScreen` abstraction to encapsulate all display device interactions, replacing direct hardware manipulation scattered throughout the worker logic. This improves testability, separation of concerns, and makes the screen lifecycle easier to manage.

Key changes:
- Extracts screen hardware operations (enable, disable, clear, draw, flip) into a dedicated service registered as a singleton via DI
- Injects the screen into the worker instead of instantiating the I2C device and display driver inline
- Fixes screen rotation by correctly applying horizontal and vertical flips during initialization
- Renames `DisplayConfiguration` to `ScreenConfiguration` for consistency with the new abstraction
- Moves screen setup out of the main execution loop, simplifying the worker's background task logic